### PR TITLE
Fix race condition with rc_.pc

### DIFF
--- a/rog_map/src/rog_map/rog_map.cpp
+++ b/rog_map/src/rog_map/rog_map.cpp
@@ -291,8 +291,10 @@ void ROGMap::cloudCallback(const sensor_msgs::PointCloud2ConstPtr& cloud_msg) {
         std::cout << YELLOW << " -- [ROS] Odom timeout, skip cloud callback." << RESET << std::endl;
         return;
     }
-    pcl::fromROSMsg(*cloud_msg, rc_.pc);
+    PointCloud temp_pc
+    pcl::fromROSMsg(*cloud_msg, temp_pc);
     rc_.updete_lock.lock();
+    rc_.pc = tmp_pc;
     rc_.pc_pose = std::make_pair(robot_state_.p, robot_state_.q);
     rc_.unfinished_frame_cnt++;
     map_empty_ = false;


### PR DESCRIPTION
First of all let me thank everyone involved in this awesome package :smile:.

This pull request addresses a race condition in the handling of **rc_.pc**. The issue occurred because this variable was being written inside **cloudCallback()** out of the mutex guard, while at the same time being accessed in **updateCallback()**. This could lead to a problem when using a ROS multi-threaded spinner to handle ROS callbacks.

To fix it I just added a temp pointcloud to store the data outside the mutex guard, to later copy into **rc_.pc**.